### PR TITLE
Reintroduce Spawnpoint scanning

### DIFF
--- a/docs/extras/spawnpoint-scanning-scheduler.md
+++ b/docs/extras/spawnpoint-scanning-scheduler.md
@@ -1,47 +1,43 @@
 # Spawnpoint Scanning Scheduler
 
-If you already have a large number of known spawnpoints it may be worth looking into Spawnpoint Scanning
+If you already have a 100% completed Initial Scan, it may be worth looking into Spawnpoint Scanning.
 
-Spawnpoint Scanning consists of only scanning an area in which a spawn has recently happened, this saves a large number of requests and also detects all spawns soon after they appear instead of whenever the scan gets round to them again
+Spawnpoint Scanning consists of only scanning an area in which a spawn has recently happened, this saves a large number of requests and also detects all spawns soon after they appear instead of whenever the scan gets round to them again.
 
-Spawnpoint Scanning is particularly useful in areas where spawns are spread out
+Spawnpoint Scanning is particularly useful in areas where spawns are spread out.
 
-## Spawnpoint Scanning can be run in one of three different modes:
+## Spawnpoint Scanning can be run in one of two different modes:
 
-### Scans based on database
+### Scans without Spawnpoint Clustering
 
 ```
 python runserver.py -ss -l YOURLOCATION -st STEPS
 ```
 
-Where YOURLOCATION is the location the map should be centered at and also the center of the hex to get spawn locations from, -st sets the size of the clipping hexagon (hexagon is the same size as the scan of the same -st value)
+Where YOURLOCATION is the location the map should be centered at and also the center of the hex to get spawn locations from, -st sets the size of the clipping hexagon (hexagon is the same size as the scan of the same -st value).
 
-This is particularly useful for when using a beehive
+This is particularly useful for when using a beehive.
 
-Note: when using the mode when not in a beehive, it is recommended to use an -st value one higher than the scan was done on, to avoid very edge spawns being clipped off
+Note: When using the mode when not in a beehive, it is recommended to use an -st value one higher than the scan was done on, to avoid very edge spawns being clipped off
 
-### Dump scans from database then use the created file
-
-```
-python runserver.py -ss YOURFILE.json -l YOURLOCATION -st STEPS --dump-spawnpoints
-```
-
-Where YOURFILE.json is the file containing all the spawns, YOURLOCATION is the location the map should be centered at and also the center of the hex to get spawn locations from and -st sets the size of the clipping hexagon (hexagon is the same size as the scan of the same -st value)
-
-This mode is mainly used for switching from database mode to spawnFile mode, and can also be used simply for dumping all spawns to file (use a very large -st and close the program once it has created the file)
-
-### Scans based on file
+### Scans with Spawnpoint Clustering
 
 ```
-python runserver.py -ss YOURFILE.json -l YOURLOCATION
+python runserver.py -ss -ssct YOURVALUE -l YOURLOCATION -st STEPS
 ```
 
-Where YOURFILE.json is the file containing all the spawns, and YOURLOCATION is the location the map should be centered at (YOURLOCATION is not used for anything else in this mode)
+Where YOURLOCATION is the location the map should be centered at and also the center of the hex to get spawn locations from, -st sets the size of the clipping hexagon (hexagon is the same size as the scan of the same -st value), -ssct (Spawnpoint Cluster Time) sets a Time threshold (in seconds) for spawn point clustering.
+ A Value around 200 seconds is recommended.
+ Spawnpoint Clustering can help to reduce requests and also your worker count because its compressing several Spawnpoints into a cluster. Cluster time will try to schedule scans at the same position within -ssct amount of seconds to catch multiple spawns at once.
 
-Note: in this mode -st does nothing
+
+
+This is particularly useful for when using a beehive.
+
+Note: When using the mode when not in a beehive, it is recommended to use an -st value one higher than the scan was done on, to avoid very edge spawns being clipped off.
+
+
 
 ### Getting spawns
 
-for generating the spawns to use with Spawnpoint Scanning it is recommended to scan the area with a scan that completes in 10 minutes for at least 1 hour, this should guarantee that all spawns are found
-
-spawn files can also be generated with an external tool such as spawnScan
+For generating the spawns to use with Spawnpoint Scanning it is recommended to scan the area with -speed until the initial scan reaches 100%.

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -245,6 +245,9 @@
                             Use spawnpoint scanning (instead of hex grid). Scans
                             in a circle based on step_limit when on DB. [env var:
                             POGOMAP_SPAWNPOINT_SCANNING]
+      -ssct SS_CLUSTER_TIME, --ss-cluster-time SS_CLUSTER_TIME
+                            Time threshold in seconds for spawn point clustering
+                            (0 to disable). [env var: POGOMAP_SS_CLUSTER_TIME]                      
       -speed, --speed-scan  Use speed scanning to identify spawn points and then
                             scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
       -spin, --pokestop-spinning

--- a/pogom/cluster.py
+++ b/pogom/cluster.py
@@ -1,0 +1,107 @@
+from .utils import distance
+from .transform import intermediate_point
+
+
+class SpawnCluster(object):
+    def __init__(self, spawnpoint):
+        self._spawnpoints = [spawnpoint]
+        self.centroid = (spawnpoint['lat'], spawnpoint['lng'])
+        self.min_time = spawnpoint['time']
+        self.max_time = spawnpoint['time']
+        self.spawnpoint_id = spawnpoint['spawnpoint_id']
+        self.appears = spawnpoint['appears']
+        self.leaves = spawnpoint['leaves']
+
+    def __getitem__(self, key):
+        return self._spawnpoints[key]
+
+    def __iter__(self):
+        for x in self._spawnpoints:
+            yield x
+
+    def __contains__(self, item):
+        return item in self._spawnpoints
+
+    def __len__(self):
+        return len(self._spawnpoints)
+
+    def append(self, spawnpoint):
+        self.centroid = self.new_centroid(spawnpoint)
+
+        self._spawnpoints.append(spawnpoint)
+
+        if spawnpoint['time'] < self.min_time:
+            self.min_time = spawnpoint['time']
+
+        elif spawnpoint['time'] > self.max_time:
+            self.max_time = spawnpoint['time']
+            self.spawnpoint_id = spawnpoint['spawnpoint_id']
+            self.appears = spawnpoint['appears']
+            self.leaves = spawnpoint['leaves']
+
+    def get_score(self, spawnpoint, time_threshold):
+        min_time = min(self.min_time, spawnpoint['time'])
+        max_time = max(self.max_time, spawnpoint['time'])
+        sp_position = (spawnpoint['lat'], spawnpoint['lng'])
+
+        if max_time - min_time > time_threshold:
+            return float('inf')
+        else:
+            return distance(sp_position, self.centroid)
+
+    def new_centroid(self, spawnpoint):
+        sp_count = len(self._spawnpoints)
+        f = sp_count / (sp_count + 1.0)
+        new_centroid = intermediate_point(
+            (spawnpoint['lat'], spawnpoint['lng']), self.centroid, f)
+
+        return new_centroid
+
+    def test_spawnpoint(self, spawnpoint, radius, time_threshold):
+        # Discard spawn points outside the time frame or too far away.
+        if self.get_score(spawnpoint, time_threshold) > 2 * radius:
+            return False
+
+        new_centroid = self.new_centroid(spawnpoint)
+
+        # Check if spawn point is within range of the new centroid.
+        if (distance((spawnpoint['lat'], spawnpoint['lng']), new_centroid) >
+                radius):
+            return False
+
+        # Check if cluster's spawn points remain in range of the new centroid.
+        if any(distance((x['lat'], x['lng']), new_centroid) >
+                radius for x in self._spawnpoints):
+            return False
+
+        return True
+
+
+# Group spawn points with similar spawn times that are close to each other.
+def cluster_spawnpoints(spawnpoints, radius=70, time_threshold=240):
+    # Initialize cluster list with the first spawn point available.
+    clusters = [SpawnCluster(spawnpoints.pop())]
+    for sp in spawnpoints:
+        # Pick the closest cluster compatible to current spawn point.
+        c = min(clusters, key=lambda x: x.get_score(sp, time_threshold))
+
+        if c.test_spawnpoint(sp, radius, time_threshold):
+            c.append(sp)
+        else:
+            c = SpawnCluster(sp)
+            clusters.append(c)
+
+    # Output new spawn points from generated clusters. Use the latest time
+    # to be sure that every spawn point in the cluster has already spawned.
+    result = []
+    for c in clusters:
+        result.append({
+            'spawnpoint_id': c.spawnpoint_id,
+            'lat': c.centroid[0],
+            'lng': c.centroid[1],
+            'time': c.max_time,
+            'appears': c.appears,
+            'leaves': c.leaves
+        })
+
+    return result

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -7,7 +7,6 @@ import calendar
 import sys
 import gc
 import time
-import geopy
 import math
 
 import s2sphere
@@ -1324,63 +1323,7 @@ class SpawnPoint(LatLongModel):
 
         return list(spawnpoints.values())
 
-    @staticmethod
-    def get_spawnpoints_in_hex(center, steps):
-
-        log.info('Finding spawnpoints {} steps away.'.format(steps))
-
-        n, e, s, w = hex_bounds(center, steps)
-
-        query = (SpawnPoint
-                 .select(SpawnPoint.latitude.alias('lat'),
-                         SpawnPoint.longitude.alias('lng'),
-                         SpawnPoint.id,
-                         SpawnPoint.earliest_unseen,
-                         SpawnPoint.latest_seen,
-                         SpawnPoint.kind,
-                         SpawnPoint.links,
-                         ))
-        query = (query.where((SpawnPoint.latitude <= n) &
-                             (SpawnPoint.latitude >= s) &
-                             (SpawnPoint.longitude >= w) &
-                             (SpawnPoint.longitude <= e)
-                             ))
-        # Sqlite doesn't support distinct on columns.
-        if args.db_type == 'mysql':
-            query = query.distinct(SpawnPoint.id)
-        else:
-            query = query.group_by(SpawnPoint.id)
-
-        with SpawnPoint.database().execution_context():
-            s = list(query.dicts())
-
-        # The distance between scan circles of radius 70 in a hex is 121.2436
-        # steps - 1 to account for the center circle then add 70 for the edge.
-        step_distance = ((steps - 1) * 121.2436) + 70
-        # Compare spawnpoint list to a circle with radius steps * 120.
-        # Uses the direct geopy distance between the center and the spawnpoint.
-        filtered = []
-
-        for idx, sp in enumerate(s):
-            if geopy.distance.distance(
-                    center, (sp['lat'], sp['lng'])).meters <= step_distance:
-                filtered.append(s[idx])
-
-        # We use 'time' as appearance time as this was how things worked
-        # previously we now also include 'disappear_time' because we
-        # can and it is meaningful in a list of spawn data
-        # the other changes also maintain a similar file format
-        for sp in filtered:
-            sp['time'], sp['disappear_time'] = SpawnPoint.start_end(sp)
-            del sp['earliest_unseen']
-            del sp['latest_seen']
-            del sp['kind']
-            del sp['links']
-            sp['spawnpoint_id'] = sp['id']
-            del sp['id']
-
-        return filtered
-
+   
     # Confirm if tth has been found.
     @staticmethod
     def tth_found(sp):

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -47,7 +47,6 @@ add it to __scheduler_classes
 import itertools
 import logging
 import math
-import json
 import time
 import sys
 from timeit import default_timer
@@ -64,6 +63,7 @@ from .models import (hex_bounds, SpawnPoint, ScannedLocation,
 from .utils import now, cur_sec, cellid, distance
 from .altitude import get_altitude
 from .geofence import Geofences
+from .cluster import cluster_spawnpoints
 
 log = logging.getLogger(__name__)
 
@@ -352,30 +352,48 @@ class SpawnScan(BaseScheduler):
             self.step_distance = 0.070
 
         self.step_limit = args.step_limit
-        self.locations = False
+        self.locations = []
+ 
+        self.cluster_range = 70
+        if self.args.jitter:
+            self.cluster_range = 65
 
     # Generate locations is called when the locations list is cleared - the
     # first time it scans or after a location change.
     def _generate_locations(self):
-        # Attempt to load spawns from file.
-        if self.args.spawnpoint_scanning != 'nofile':
-            log.debug('Loading spawn points from json file @ %s',
-                      self.args.spawnpoint_scanning)
-            try:
-                with open(self.args.spawnpoint_scanning) as file:
-                    self.locations = json.load(file)
-            except ValueError as e:
-                log.error('JSON error: %s; will fallback to database', repr(e))
-            except IOError as e:
-                log.error(
-                    'Error opening json file: %s; will fallback to database',
-                    repr(e))
 
         # No locations yet? Try the database!
-        if not self.locations:
-            log.debug('Loading spawn points from database')
-            self.locations = SpawnPoint.get_spawnpoints_in_hex(
-                self.scan_location, self.args.step_limit)
+        if not self.locations and not self.args.no_pokemon:
+            log.debug('Loading spawn points from database.')
+ 
+            spawns = SpawnPoint.select_in_hex_by_location(
+                self.scan_location, self.step_limit)
+ 
+            log.debug('Loaded %s spawn points from database.' % len(spawns))
+ 
+            for sp in spawns:
+                time, disappear_time = SpawnPoint.start_end(sp)
+ 
+                if time > cur_sec():
+                    # Hasn't spawn in the current hour.
+                    from_now = time - cur_sec()
+                    appears = now() + from_now
+                else:
+                    # Won't spawn until next hour.
+                    late_by = cur_sec() - time
+                    appears = now() + 3600 - late_by
+ 
+                duration = (disappear_time - time) % 3600
+                leaves = appears + duration
+ 
+                self.locations.append({
+                    'spawnpoint_id': sp['id'],
+                    'lat': sp['latitude'],
+                    'lng': sp['longitude'],
+                    'time': time,
+                    'appears': appears,
+                    'leaves': leaves
+                })
 
         # Geofence spawnpoints.
         if self.geofences.is_enabled():
@@ -387,57 +405,18 @@ class SpawnScan(BaseScheduler):
                 sys.exit()
 
         # Well shit...
-        # if not self.locations:
-        #    raise Exception('No availabe spawn points!')
+            if not self.locations:
+               raise Exception('No available spawn points!')
 
-        # locations[]:
-        # {"lat": 37.53079079414139, "lng": -122.28811690874117,
-        #  "spawnpoint_id": "808f9f1601d", "time": 511
+        log.info('Tracking a total of %d spawn points.', len(self.locations))
 
-        log.info('Total of %d spawns to track', len(self.locations))
-
-        # locations.sort(key=itemgetter('time'))
-
-        if self.args.verbose:
-            for i in self.locations:
-                sec = i['time'] % 60
-                minute = (i['time'] / 60) % 60
-                m = 'Scan [{:02}:{:02}] ({}) @ {},{}'.format(
-                    minute, sec, i['time'], i['lat'], i['lng'])
-                log.debug(m)
-
-        # 'time' from json and db alike has been munged to appearance time as
-        # seconds after the hour.
-        # Here we'll convert that to a real timestamp.
-        for location in self.locations:
-            # For a scan which should cover all CURRENT pokemon, we can offset
-            # the comparison time by 15 minutes so that the "appears" time
-            # won't be rolled over to the next hour.
-
-            # TODO: Make it work. The original logic (commented out) was
-            #       producing bogus results if your first scan was in the last
-            #       15 minute of the hour. Wrapping my head around this isn't
-            #       work right now, so I'll just drop the feature for the time
-            #       being. It does need to come back so that
-            #       repositioning/pausing works more nicely, but we can live
-            #       without it too.
-
-            # if sps_scan_current:
-            #     cursec = (location['time'] + 900) % 3600
-            # else:
-            cursec = location['time']
-
-            if cursec > cur_sec():
-                # Hasn't spawn in the current hour.
-                from_now = location['time'] - cur_sec()
-                appears = now() + from_now
-            else:
-                # Won't spawn till next hour.
-                late_by = cur_sec() - location['time']
-                appears = now() + 3600 - late_by
-
-            location['appears'] = appears
-            location['leaves'] = appears + 900
+        # Cluster spawnpoints.
+        if self.args.ss_cluster_time > 0:
+            self.locations = cluster_spawnpoints(
+                self.locations, self.cluster_range, self.args.ss_cluster_time)
+            log.info('Compressed spawn points into %d clusters.',
+                    len(self.locations))
+  
 
         # Put the spawn points in order of next appearance time.
         self.locations.sort(key=itemgetter('appears'))
@@ -445,11 +424,10 @@ class SpawnScan(BaseScheduler):
         # Match expected structure:
         # locations = [((lat, lng, alt), ts_appears, ts_leaves),...]
         retset = []
-        for step, location in enumerate(self.locations, 1):
-            altitude = get_altitude(self.args, [location['lat'],
-                                                location['lng']])
-            retset.append((step, (location['lat'], location['lng'], altitude),
-                           location['appears'], location['leaves']))
+        for step, sp in enumerate(self.locations, 1):
+            altitude = get_altitude(self.args, [sp['lat'], sp['lng']])
+            retset.append((step, (sp['lat'], sp['lng'], altitude),
+                            sp['appears'], sp['leaves']))
 
         return retset
 
@@ -457,7 +435,7 @@ class SpawnScan(BaseScheduler):
     def schedule(self):
         if not self.scan_location:
             log.warning(
-                'Cannot schedule work until scan location has been set')
+                'Cannot schedule work until scan location has been set.')
             return
 
         # SpawnScan needs to calculate the list every time, since the times
@@ -471,10 +449,50 @@ class SpawnScan(BaseScheduler):
             log.debug("Added location {}".format(location))
 
         # Clear the locations list so it gets regenerated next cycle.
-        self.locations = None
+        self.locations = []
         self.ready = True
 
-
+    def next_item(self, status):
+        step, step_location, appears, leaves = self.queues[0].get()
+ 
+        wait = 0
+        wait_msg = 'Waiting for item from queue.'
+ 
+        worker_loc = (status['latitude'], status['longitude'])
+        if worker_loc[0] and worker_loc[1] and self.args.kph:
+            now_date = datetime.utcnow()
+            last_action = status['last_scan_date']
+            meters = distance(step_location, worker_loc)
+            wait = int(max(meters / self.args.kph * 3.6
+                            - (now_date - last_action).total_seconds(), 0))
+            if wait > 0:
+                wait_msg = 'Moving {}m to step {}, arriving in {}s.'.format(
+                    int(meters), step, wait)
+ 
+        remain = appears - now() - wait + 10
+        messages = {
+            'wait': wait_msg,
+            'early': 'Early for {:6f},{:6f}; waiting {}s...'.format(
+                step_location[0], step_location[1], remain),
+            'late': 'Too late for location {:6f},{:6f}; skipping.'.format(
+                step_location[0], step_location[1]),
+            'search': 'Searching at {:6f},{:6f},{:6f}.'.format(
+                step_location[0], step_location[1], step_location[2]),
+            'invalid': ('Invalid response at {:6f},{:6f}, ' +
+                        'abandoning location.').format(step_location[0],
+                                                        step_location[1])
+        }
+ 
+        if remain < self.args.min_seconds_left:
+            messages['wait'] = ('Unable to reach {:6f},{:6f}, under the ' +
+                                'speed limit.').format(step_location[0],
+                                                        step_location[1])
+            # Future improvement: insert the item back into the queue, hoping
+            # that another worker may reach the scan location in time.
+            return -1, 0, 0, 0, messages, 0
+ 
+        return step, step_location, appears, leaves, messages, wait
+ 
 # SpeedScan is a complete search method that initially does a spawnpoint
 # search in each scan location by scanning five two-minute bands within
 # an hour and ten minute intervals between bands.

--- a/pogom/transform.py
+++ b/pogom/transform.py
@@ -100,3 +100,44 @@ def jitter_location(location=None, max_meters=5):
     distance = math.sqrt(random.random()) * (float(max_meters))
     destination = fast_get_new_coords(origin, distance, bearing)
     return (destination[0], destination[1], location[2])
+
+
+ 
+# Computes the intermediate point at any fraction along the great circle path.
+def intermediate_point(pos1, pos2, fraction):
+    if pos1 == pos2:
+        return pos1
+ 
+    lat1 = math.radians(pos1[0])
+    lon1 = math.radians(pos1[1])
+    lat2 = math.radians(pos2[0])
+    lon2 = math.radians(pos2[1])
+ 
+    # Spherical Law of Cosines.
+    slc = (math.sin(lat1) * math.sin(lat2) +
+           math.cos(lat1) * math.cos(lat2) * math.cos(lon2 - lon1))
+
+    if slc > 1:
+        # Locations are too close to each other.
+        return pos1 if fraction < 0.5 else pos2
+ 
+    delta = math.acos(slc)
+ 
+    if delta == 0:
+        # Locations are too close to each other.
+        return pos1 if fraction < 0.5 else pos2
+ 
+    # Intermediate point.
+    a = math.sin((1 - fraction) * delta) / delta
+    b = math.sin(fraction * delta) / delta
+    x = (a * math.cos(lat1) * math.cos(lon1) + 
+         b * math.cos(lat2) * math.cos(lon2))
+    y = (a * math.cos(lat1) * math.sin(lon1) +
+         b * math.cos(lat2) * math.sin(lon2))
+    z = a * math.sin(lat1) + b * math.sin(lat2)
+ 
+    lat3 = math.atan2(z, math.sqrt(x**2 + y**2))
+    lon3 = math.atan2(y, x)
+ 
+    return (((math.degrees(lat3) + 540) % 360) - 180,
+            ((math.degrees(lon3) + 540) % 360) - 180)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -321,7 +321,11 @@ def get_args():
                         help=('Use spawnpoint scanning (instead of hex ' +
                               'grid). Scans in a circle based on step_limit ' +
                               'when on DB.'),
-                        nargs='?', const='nofile', default=False)
+                        action='store_true', default=False)
+    parser.add_argument('-ssct', '--ss-cluster-time',
+                        help=('Time threshold in seconds for spawn point ' +
+                              'clustering (0 to disable).'),
+                        type=int, default=0)
     parser.add_argument('-speed', '--speed-scan',
                         help=('Use speed scanning to identify spawn points ' +
                               'and then scan closest spawns.'),
@@ -344,10 +348,6 @@ def get_args():
                         help=('Change duration for lures set on pokestops. ' +
                               'This is useful for events that extend lure ' +
                               'duration.'), type=int, default=30)
-    parser.add_argument('--dump-spawnpoints',
-                        help=('Dump the spawnpoints from the db to json ' +
-                              '(only for use with -ss).'),
-                        action='store_true', default=False)
     parser.add_argument('-pd', '--purge-data',
                         help=('Clear Pokemon from database this many hours ' +
                               'after they disappear (0 to disable).'),

--- a/runserver.py
+++ b/runserver.py
@@ -7,7 +7,6 @@ import logging
 import time
 import re
 import ssl
-import json
 import requests
 
 from distutils.version import StrictVersion
@@ -25,7 +24,7 @@ from pogom.utils import (get_args, now, gmaps_reverse_geolocate, init_args,
 from pogom.altitude import get_gmaps_altitude
 
 from pogom.models import (init_database, create_tables, drop_tables,
-                          PlayerLocale, SpawnPoint, db_updater, clean_db_loop,
+                          PlayerLocale, db_updater, clean_db_loop,
                           verify_table_encoding, verify_database_schema)
 from pogom.webhook import wh_updater
 
@@ -432,18 +431,6 @@ def main():
 
         # Gather the Pokemon!
 
-        # Attempt to dump the spawn points (do this before starting threads of
-        # endure the woe).
-        if (args.spawnpoint_scanning and
-                args.spawnpoint_scanning != 'nofile' and
-                args.dump_spawnpoints):
-            with open(args.spawnpoint_scanning, 'w+') as file:
-                log.info(
-                    'Saving spawn points to %s', args.spawnpoint_scanning)
-                spawns = SpawnPoint.get_spawnpoints_in_hex(
-                    position, args.step_limit)
-                file.write(json.dumps(spawns))
-                log.info('Finished exporting spawn points')
 
         argset = (args, new_location_queue, control_flags,
                   heartbeat, db_updates_queue, wh_updates_queue)


### PR DESCRIPTION
based of the commit of Rocketmap.

This is also on RM work in progress.
taken 1:1 form rocketmap and tested it locally.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This introduced Spawnpoint scanning back into Rocketmap.
However, you first need to do an initial scan with -speed to gather all spawnpoints.
after that you can change -speed to -ss an optional with cluster spawning scanning.

Beware, i have tested this for 2 days, and it does somehow work!!
it doesnt break anything regarding -speed scanning, but there are downsides.
Not all pokemons are being scanned, i havent found out why and RM propably also not.
since i didnt got much feedback from them.

## Motivation and Context
This re-introduced spawnpoint scanning.
pro: less workers, in a -st you can use 5 to 10 workers.. also less hashing and captha.


## How Has This Been Tested?
Tested this on my server along my normal instance.
so i was able to compare same area with -speed also with -ss ( and with and without cluster spawning )

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
