### PR TITLE
Added wh-timeout based on RM

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -333,9 +333,12 @@
       -whr WH_RETRIES, --wh-retries WH_RETRIES
                             Number of times to retry sending webhook data on
                             failure. [env var: POGOMAP_WH_RETRIES]
-      -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
-                            Timeout (in seconds) for webhook requests. [env var:
-                            POGOMAP_WH_TIMEOUT]
+      -whct WH_CONNECT_TIMEOUT, --wh-connect-timeout WH_CONNECT_TIMEOUT
+                            Connect timeout (in seconds) for webhook requests.
+                            [env var: POGOMAP_WH_CONNECT_TIMEOUT]
+      -whrt WH_READ_TIMEOUT, --wh-read-timeout WH_READ_TIMEOUT
+                            Read timeout (in seconds) for webhook requests.
+                            [env var: POGOMAP_WH_READ_TIMEOUT]
       -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
                             Factor (in seconds) by which the delay until next
                             retry will increase. [env var:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -430,8 +430,13 @@ def get_args():
                         help=('Number of times to retry sending webhook ' +
                               'data on failure.'),
                         type=int, default=3)
-    parser.add_argument('-wht', '--wh-timeout',
-                        help='Timeout (in seconds) for webhook requests.',
+    parser.add_argument('-whct', '--wh-connect-timeout',
+                         help=('Connect timeout (in seconds) for webhook' +
+						 ' requests.'),
+                        type=float, default=1.0)
+    parser.add_argument('-whrt', '--wh-read-timeout',
+                        help=('Read timeout (in seconds) for webhook' +
+						'requests.'),
                         type=float, default=1.0)
     parser.add_argument('-whbf', '--wh-backoff-factor',
                         help=('Factor (in seconds) by which the delay ' +

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -188,7 +188,7 @@ def __wh_future_completed(future):
         exc = future.exception(timeout=0)
 
         if exc:
-            log.exception("Something's wrong with your webhook: %s.", exc)
+            log.warning("Something's wrong with your webhook: %s.", exc)
     except Exception as ex:
         log.exception('Unexpected exception in exception info: %s.', ex)
 

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -22,14 +22,15 @@ def send_to_webhooks(args, session, message_frame):
         log.critical('Called send_to_webhook() without webhooks.')
         return
 
-    req_timeout = args.wh_timeout
+    connect_timeout = args.wh_connect_timeout
+    read_timeout = args.wh_read_timeout
 
     for w in args.webhooks:
         try:
             # Disable keep-alive and set streaming to True, so we can skip
             # the response content.
             future = session.post(w, json=message_frame,
-                                  timeout=(None, req_timeout),
+                                  timeout=(connect_timeout, read_timeout),
                                   background_callback=__wh_request_completed,
                                   headers={'Connection': 'close'},
                                   stream=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a connect timeout to webhook messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoids queue buildup when people have an unresponsive receiving webhook server.

This'll also help to make it clearer to people when they should get their receiving webhook servers fixed, instead of thinking that RocketMap is intentionally holding expired messages in the queue (one example which had a queue delay of over two hours).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X]  Enhancement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
