### PR TITLE
Adds geofence setting to RM front-end

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -17,7 +17,7 @@ from pogom.utils import get_args, get_pokemon_name
 from bisect import bisect_left
 
 from pogom.weather import get_weather_cells, get_s2_coverage, get_weather_alerts
-from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
+from .models import (Geofence, Pokemon, Gym, Pokestop, ScannedLocation,
                      MainWorker, WorkerStatus, Token, HashKeys,
                      SpawnPoint)
 from .utils import (get_pokemon_name, get_pokemon_types, get_pokemon_rarity,
@@ -291,6 +291,8 @@ class Pogom(Flask):
                                  args.spawnpoint_scanning) else True
 
         visibility_flags = {
+		    'geofences': bool(args.geofence_file or
+			                  args.geofence_excluded_file),
             'gyms': not args.no_gyms,
             'pokemons': not args.no_pokemon,
             'pokestops': not args.no_pokestops,
@@ -521,6 +523,28 @@ class Pogom(Flask):
                             swLat, swLng, neLat, neLng,
                             oSwLat=oSwLat, oSwLng=oSwLng,
                             oNeLat=oNeLat, oNeLng=oNeLng))
+
+        if request.args.get('geofences', 'true') == 'true':
+            db_geofences = Geofence.get_geofences()
+
+            geofences = {}
+            for g in db_geofences:
+                # Check if already there
+                geofence = geofences.get(g['name'], None)
+                if not geofence:  # Create a new sub-dict if new
+                    geofences[g['name']] = {
+                        'excluded': g['excluded'],
+                        'name': g['name'],
+                        'coordinates': []
+                    }
+                coordinate = {
+                    'lat': g['latitude'],
+                    'lng': g['longitude']
+                }
+                geofences[g['name']]['coordinates'].append(coordinate)
+
+            d['geofences'] = geofences
+
 
         if request.args.get('status', 'false') == 'true':
             args = get_args()

--- a/pogom/geofence.py
+++ b/pogom/geofence.py
@@ -6,6 +6,7 @@ import timeit
 import logging
 
 from .utils import get_args
+from .models import Geofence
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class Geofences:
                 args.geofence_file, excluded=False)
             self.excluded_areas = self.parse_geofences_file(
                 args.geofence_excluded_file, excluded=True)
+            Geofence.push_geofences(self.geofenced_areas+self.excluded_areas)
             log.info('Loaded %d geofenced and %d excluded areas.',
                      len(self.geofenced_areas),
                      len(self.excluded_areas))

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -105,6 +105,75 @@ class LatLongModel(BaseModel):
                         result['latitude'], result['longitude'])
         return results
 
+		# Geofence DB Model
+class Geofence(BaseModel):
+    name = Utf8mb4CharField(max_length=50)
+    excluded = BooleanField()
+    coordinates_id = SmallIntegerField()
+    latitude = DoubleField()
+    longitude = DoubleField()
+
+    class Meta:
+        primary_key = False
+
+    @staticmethod
+    def clear_all():
+        # Remove all geofences without interfering with other threads.
+        with flaskDb.database.transaction():
+            DeleteQuery(Geofence).execute()
+
+    @staticmethod
+    def remove_duplicates(geofences):
+        # Remove old geofences without interfering with other DB threads.
+        with flaskDb.database.transaction():
+            for g in geofences:
+                (DeleteQuery(Geofence)
+                 .where(Geofence.name == g['name'])
+                 .execute())
+
+    @staticmethod
+    def push_geofences(geofences):
+        Geofence.remove_duplicates(geofences)
+
+        db_geofences = []
+        for g in geofences:
+            coordinates_id = 0
+            for c in g['polygon']:
+                db_geofences.append({
+                    'excluded': g['excluded'],
+                    'name': g['name'],
+                    'coordinates_id': coordinates_id,
+                    'latitude': c['lat'],
+                    'longitude': c['lon']
+                })
+                coordinates_id = coordinates_id + 1
+
+        # Make a DB save.
+        with flaskDb.database.transaction():
+            Geofence.insert_many(db_geofences).execute()
+
+        return db_geofences
+
+    @staticmethod
+    def get_geofences():
+        query = Geofence.select().dicts()
+
+        # Performance:  disable the garbage collector prior to creating a
+        # (potentially) large dict with append().
+        gc.disable()
+
+        geofences = []
+        for g in query:
+            if args.china:
+                g['polygon']['latitude'], g['polygon']['longitude'] = \
+                    transform_from_wgs_to_gcj(g['polygon']['latitude'],
+                                              g['polygon']['longitude'])
+            geofences.append(g)
+
+        # Re-enable the GC.
+        gc.enable()
+
+        return geofences
 
 class Pokemon(LatLongModel):
     # We are base64 encoding the ids delivered by the api
@@ -2919,7 +2988,7 @@ def bulk_upsert(cls, data, db):
 
 
 def create_tables(db):
-    tables = [Pokemon, Pokestop, Gym, Raid, ScannedLocation, GymDetails,
+    tables = [Geofence, Pokemon, Pokestop, Gym, Raid, ScannedLocation, GymDetails,
               GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus,
               SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData,
               Token, LocationAltitude, PlayerLocale, HashKeys, Weather]
@@ -2934,7 +3003,7 @@ def create_tables(db):
 
 
 def drop_tables(db):
-    tables = [Pokemon, Pokestop, Gym, Raid, ScannedLocation, Versions,
+    tables = [Geofence, Pokemon, Pokestop, Gym, Raid, ScannedLocation, Versions,
               GymDetails, GymMember, GymPokemon, Trainer, MainWorker,
               WorkerStatus, SpawnPoint, ScanSpawnPoint,
               SpawnpointDetectionData, LocationAltitude, PlayerLocale,

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -958,6 +958,10 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
+	'showGeofences': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     'playSound': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -61,6 +61,9 @@ var lastpokemon
 var lastslocs
 var lastspawns
 
+var polygons = []
+var geofencesSet = false
+
 var selectedStyle = 'light'
 
 var updateWorker
@@ -490,6 +493,7 @@ function initSidebar() {
     $('#weather-cells-switch').prop('checked', Store.get('showWeatherCells'))
     $('#s2cells-switch').prop('checked', Store.get('showS2Cells'))
     $('#weather-alerts-switch').prop('checked', Store.get('showWeatherAlerts'))
+	$('#geofences-switch').prop('checked', Store.get('showGeofences'))
 
     // Only create the Autocomplete element if it's enabled in template.
     var elSearchBox = document.getElementById('next-location')
@@ -1006,6 +1010,29 @@ function spawnpointLabel(item) {
     return str
 }
 
+function geofenceLabel(item) {
+    var str
+    if (item.excluded) {
+        str = `
+            <div>
+                <b>Excluded Area</b>
+            </div>`
+    } else {
+        str = `
+            <div>
+                <b>Geofence</b>
+            </div>`
+    }
+
+    str += `
+        <div>
+            ${item.name}
+        </div>`
+
+    return str
+}
+
+
 function addRangeCircle(marker, map, type, teamId) {
     var targetmap = null
     var circleCenter = new google.maps.LatLng(marker.position.lat(), marker.position.lng())
@@ -1432,6 +1459,62 @@ function setupSpawnpointMarker(item) {
     return marker
 }
 
+function setupGeofencePolygon(item) {
+    var randomcolor = randomColor()
+    // Random with color seed randomColor({hue: 'pink'})
+    // Total random '#'+Math.floor(Math.random()*16777215).toString(16);
+    if (item.excluded === true) {
+        randomcolor = randomColor({hue: 'red'})
+    } else {
+        randomcolor = randomColor({hue: 'green'})
+    }
+
+    var polygon = new google.maps.Polygon({
+        map: map,
+        paths: item['coordinates'],
+        strokeColor: randomcolor,
+        strokeOpacity: 0.8,
+        strokeWeight: 2,
+        fillColor: randomcolor,
+        fillOpacity: 0.5
+    })
+
+    var markerPosition = polygonCenter(polygon)
+
+    polygon.infoWindow = new google.maps.InfoWindow({
+        content: geofenceLabel(item),
+        disableAutoPan: true,
+        position: markerPosition
+    })
+
+    addListeners(polygon)
+
+    return polygon
+}
+
+function polygonCenter(polygon) {
+    var hyp, Lat, Lng
+
+    var X = 0
+    var Y = 0
+    var Z = 0
+    polygon.getPath().forEach(function (vertex, inex) {
+        var lat
+        var lng
+        lat = vertex.lat() * Math.PI / 180
+        lng = vertex.lng() * Math.PI / 180
+        X += Math.cos(lat) * Math.cos(lng)
+        Y += Math.cos(lat) * Math.sin(lng)
+        Z += Math.sin(lat)
+    })
+
+    hyp = Math.sqrt(X * X + Y * Y)
+    Lat = Math.atan2(Z, hyp) * 180 / Math.PI
+    Lng = Math.atan2(Y, X) * 180 / Math.PI
+
+    return new google.maps.LatLng(Lat, Lng)
+}
+
 function clearSelection() {
     if (document.selection) {
         document.selection.empty()
@@ -1588,6 +1671,7 @@ function loadRawData() {
     var loadWeather = Store.get('showWeatherCells')
     var loadS2Cells = Store.get('showS2Cells')
     var loadWeatherAlerts = Store.get('showWeatherAlerts')
+	var loadGeofences = Store.get('showGeofences')
 
     var bounds = map.getBounds()
     var swPoint = bounds.getSouthWest()
@@ -1612,6 +1696,7 @@ function loadRawData() {
             'scanned': loadScanned,
             'lastslocs': lastslocs,
             'spawnpoints': loadSpawnpoints,
+			'geofences': loadGeofences,
             'weather': loadWeather,
             's2cells': loadS2Cells,
             'weatherAlerts': loadWeatherAlerts,
@@ -1971,6 +2056,26 @@ function updateSpawnPoints() {
     })
 }
 
+function updateGeofences(geofences) {
+    var i
+    if (!Store.get('showGeofences') && geofencesSet === true) {
+        for (i = 0; i < polygons.length; i++) {
+            polygons[i].setMap(null)
+        }
+        polygons = []
+        geofencesSet = false
+        return false
+    } else if (Store.get('showGeofences') && geofencesSet === false) {
+        var key
+        i = 0
+        for (key in geofences) {
+            polygons[i] = setupGeofencePolygon(geofences[key])
+            i++
+        }
+        geofencesSet = true
+    }
+}
+
 function updateMap() {
     loadRawData().done(function (result) {
         processPokemons(result.pokemons)
@@ -1999,6 +2104,7 @@ function updateMap() {
         updateScanned()
         updateSpawnPoints()
         updatePokestops()
+		updateGeofences(result.geofences)
 
         if ($('#stats').hasClass('visible')) {
             countMarkers(map)
@@ -3062,7 +3168,12 @@ $(function () {
             Store.set('geoLocate', this.checked)
         }
     })
-
+	
+	$('#geofences-switch').change(function () {
+        Store.set('showGeofences', this.checked)
+        updateMap()
+    })
+	
     $('#lock-marker-switch').change(function () {
         Store.set('lockMarker', this.checked)
         searchMarker.setDraggable(!this.checked)

--- a/templates/map.html
+++ b/templates/map.html
@@ -238,6 +238,16 @@
                 </label>
               </div>
             </div>
+            <div class="form-control switch-container">
+              <h3>Geofences</h3>
+              <div class="onoffswitch">
+                <input id="geofences-switch" type="checkbox" name="geofences-switch" class="onoffswitch-checkbox">
+                <label class="onoffswitch-label" for="geofences-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
               {% if show.pokemons %}
             <div class="form-control">
               <label for="exclude-pokemon">
@@ -526,6 +536,7 @@
     <script src="https://cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/push.js/1.0.4/push.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/randomcolor/0.4.4/randomColor.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/vendor/markerclusterer.min.js').lstrip('/') }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>


### PR DESCRIPTION
+ Adds geofence option to RM front-end to show the area of a geofence directly on map
+ Adds geofence table in DB


## Description
The original work was done by [IcognitoUnown](https://github.com/IcognitoUnown) stock PR [here.](https://github.com/RocketMap/RocketMap/pull/2171)
It adds a slider for showing geofences on map and then shows the areas of your geofences you've set up for your instances.
Run **ONE** instance before you run all the other instances you have. It does a DB update (to prevent issues).
Also, dont have **multiple geofences with the same name**. It is ok to have one geofence used by more than one instance.

## Motivation and Context

I saw this PR a while ago and I like the idea to give users the option to see whats actually being scanned by the map. Also it helps determining the -st for geofence users due to the fact u can combine the option scanned location and geofence.

## How Has This Been Tested?

I've been testing it on my own map for about a week now.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7988840/35627800-5c8a45b2-069a-11e8-959b-da41f0b8b9ef.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
