### PR TITLE
Add warning on -novc

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -295,6 +295,13 @@ def main():
     # Let's not forget to run Grunt / Only needed when running with webserver.
     if not args.no_server and not validate_assets(args):
         sys.exit(1)
+ 
+    if args.no_version_check and not args.only_server:
+            log.warning('You are running RocketMap in No Version Check mode. '
+                        'If you don\'t know what you\'re doing, this mode '
+                        'can have consequences, and you will not receive '
+                        'support running in NoVC mode. You have been warned.')
+
 
     position = extract_coordinates(args.location)
     # Use the latitude and longitude to get the local altitude from Google.


### PR DESCRIPTION
Add warning on -novc



## Description
Displays warning on startup when people run in -novc mode.

## Motivation and Context
to let people know they are still in -novc mode and no support is given if you do run so and to make them aware of the consequences of running in -novc mode

## How Has This Been Tested?
stolen from stock RM 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.