### PR TITLE
Add option to disable kph and hlvl-kph.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -93,7 +93,7 @@
 #workers-per-hive:              # Only referenced when using --beehive. Sets number of workers per hive. (default=1)
 #workers:                       # Number of search worker threads to start. (default=#accounts)
 #spawn-delay:                   # Number of seconds after spawn time to wait before scanning to be sure the Pokemon is there. (default=10)
-#kph:                           # Set a maximum speed in km/hour for scanner movement. (default=35)
+#kph:                           # Set a maximum speed in km/hour for scanner movement. 0 to disable.  (default=35)
 #bad-scan-retry:                # Number of bad scans before giving up on a step. (default=2, 0 to disable)
 #skip-empty                     # Enables skipping of empty cells in normal scans - requires previously populated database. (not to be used with -ss)
 #min-seconds-left:              # Time that must be left on a spawn before considering it too late and skipping it. (default=0)
@@ -123,7 +123,7 @@
 #encounter-delay:               # Delay in seconds before starting an encounter. Must not be zero. (default=1)
 #high-lvl-accounts:             # File containing a list high level accounts, in the format "auth_service,username,password"
 #enc-whitelist-file:            # File containing a list of Pokemon IDs to encounter for IV/CPs. Requires L30 or higher accounts in --high-lvl-accounts.
-#hlvl-kph:                      # Set a maximum speed in km/hour for high level account scanning. (default=25)
+#hlvl-kph:                      # Set a maximum speed in km/hour for high level account scanning. 0 to disable. (default=25)
 
 
 # Webserver settings

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -255,11 +255,11 @@ which override config file values which override defaults.
                             Maximum number of Pokestop spins per hour. [env var:
                             POGOMAP_ACCOUNT_MAX_SPINS]
       -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
-                            [env var: POGOMAP_KPH]
+                            0 to disable. Default: 35. [env var: POGOMAP_KPH]
       -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
                             Set a maximum speed in km/hour for scanner movement,
-                            for high-level (L30) accounts. [env var:
-                            POGOMAP_HLVL_KPH]
+                            for high-level (L30) accounts. 0 to disable.
+                            Default: 25. [env var: POGOMAP_HLVL_KPH]
       -ldur LURE_DURATION, --lure-duration LURE_DURATION
                             Change duration for lures set on pokestops. This is
                             useful for events that extend lure duration. [env var:

--- a/docs/scanning-method/speed-scheduler.md
+++ b/docs/scanning-method/speed-scheduler.md
@@ -4,13 +4,14 @@ Speed Scheduler is an alternative scheduler to Hex Scan or Spawnpoint Scan with 
 
 ## Features
 
-* Limit speed according to default of 35 kph or by setting -kph
+* Limit regular scanning speed according to default of 35 km/h or by setting -kph. 0 to disable.
+* Limit high-level account encounter speed according to default of 25 km/h or by setting --hlvl-kph. 0 to disable.
 * Do an initial scan of the full area, then automatically switch to tracking down the exact spawn time (finding the TTH) and only scan for spawns (an -ss like behaviour).
 * Add spawn point type identification of the three current types of spawn points -- 15, 30, and 60 minute spawns.
-* Change spawn point scans to correct spawn time according to spawnpoint type
-* Add scans to complete identification for partially identified spawn points
-* Dynamically identify and check duration of new spawn points without requiring return to Hex scanning
-* Identify spawn points that have been removed and stop scanning them
+* Change spawn point scans to correct spawn time according to spawnpoint type.
+* Add scans to complete identification for partially identified spawn points.
+* Dynamically identify and check duration of new spawn points without requiring return to Hex scanning.
+* Identify spawn points that have been removed and stop scanning them.
 
 To use Speed Scheduler, always put -speed in the command line or set `speed-scan` in your config file.
 

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -435,11 +435,12 @@ class AccountSet(object):
                 # Check if we're below speed limit for account.
                 last_scanned = account.get('last_scanned', False)
 
-                if last_scanned:
+                if last_scanned and self.kph > 0:
                     seconds_passed = now - last_scanned
                     old_coords = account.get('last_coords', coords_to_scan)
 
                     distance_m = distance(old_coords, coords_to_scan)
+
                     cooldown_time_sec = distance_m / self.kph * 3.6
 
                     # Not enough time has passed for this one.

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -459,7 +459,7 @@ class SpawnScan(BaseScheduler):
         wait_msg = 'Waiting for item from queue.'
  
         worker_loc = (status['latitude'], status['longitude'])
-        if worker_loc[0] and worker_loc[1] and self.args.kph:
+        if worker_loc[0] and worker_loc[1] and self.args.kph > 0:
             now_date = datetime.utcnow()
             last_action = status['last_scan_date']
             meters = distance(step_location, worker_loc)
@@ -973,7 +973,7 @@ class SpeedScan(HexSearch):
 
                 # If we are going to get there before it starts then ignore.
                 loc = item['loc']
-                if worker_loc:
+                if worker_loc and self.args.kph > 0:
                     meters = distance(loc, worker_loc)
                     secs_to_arrival = meters / self.args.kph * 3.6
                     secs_waited = (now_date - last_action).total_seconds()
@@ -981,6 +981,7 @@ class SpeedScan(HexSearch):
                 else:
                     meters = 0
                     secs_to_arrival = 0
+
                 if ms + secs_to_arrival < item['start']:
                     count_early += 1
                     continue
@@ -1021,8 +1022,7 @@ class SpeedScan(HexSearch):
                           min_parked_time_remaining,
                           min_fresh_band_time_remaining)
             else:
-                log.debug('Enumerating queue found best location: %s.',
-                          repr(best))
+                log.debug('Enumerating queue found best location: %s.', best)
 
             loc = best.get('loc', [])
             step = best.get('step', 0)
@@ -1061,8 +1061,9 @@ class SpeedScan(HexSearch):
                 return -1, 0, 0, 0, messages, 0
 
             meters = distance(loc, worker_loc) if worker_loc else 0
-            if (meters > (now_date - last_action).total_seconds() *
-                    self.args.kph / 3.6):
+            if self.args.kph > 0 and (meters >
+                                      (now_date - last_action).total_seconds()
+                                      * self.args.kph / 3.6):
                 # Flag item as "parked" by a specific thread, because
                 # we're waiting for it. This will avoid all threads "walking"
                 # to the same item.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1070,7 +1070,8 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                 status['message'] = messages['wait']
                 # The next_item will return the value telling us how long
                 # to sleep. This way the status can be updated
-                time.sleep(wait)
+                if wait > 0:
+                    time.sleep(wait)
 
                 # Using step as a flag for no valid next location returned.
                 if step == -1:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -336,11 +336,12 @@ def get_args():
                         type=int, default=20)
     parser.add_argument('-kph', '--kph',
                         help=('Set a maximum speed in km/hour for scanner ' +
-                              'movement.'),
+                              'movement. 0 to disable. Default: 35.'),
                         type=int, default=35)
     parser.add_argument('-hkph', '--hlvl-kph',
                         help=('Set a maximum speed in km/hour for scanner ' +
-                              'movement, for high-level (L30) accounts.'),
+                              'movement, for high-level (L30) accounts. ' +
+                              '0 to disable. Default: 25.'),
                         type=int, default=25)
     parser.add_argument('-ldur', '--lure-duration',
                         help=('Change duration for lures set on pokestops. ' +

--- a/runserver.py
+++ b/runserver.py
@@ -287,9 +287,9 @@ def main():
     # Stop if we're just looking for a debug dump.
     if args.dump:
         log.info('Retrieving environment info...')
-        hastebin = get_debug_dump_link()
+        hastebin_id = get_debug_dump_link()
         log.info('Done! Your debug link: https://hastebin.com/%s.txt',
-                 hastebin)
+                 hastebin_id)
         sys.exit(1)
 
     # Let's not forget to run Grunt / Only needed when running with webserver.
@@ -297,10 +297,11 @@ def main():
         sys.exit(1)
  
     if args.no_version_check and not args.only_server:
-            log.warning('You are running RocketMap in No Version Check mode. '
-                        'If you don\'t know what you\'re doing, this mode '
-                        'can have consequences, and you will not receive '
-                        'support running in NoVC mode. You have been warned.')
+        log.warning('You are running RocketMap in No Version Check mode. '
+                    "If you don't know what you're doing, this mode "
+                    'can have negative consequences, and you will not '
+                    'receive support running in NoVC mode. '
+                    'You have been warned.')
 
 
     position = extract_coordinates(args.location)
@@ -308,7 +309,7 @@ def main():
     (altitude, status) = get_gmaps_altitude(position[0], position[1],
                                             args.gmaps_key)
     if altitude is not None:
-        log.debug('Local altitude is: %sm', altitude)
+        log.debug('Local altitude is: %sm.', altitude)
         position = (position[0], position[1], altitude)
     else:
         if status == 'REQUEST_DENIED':
@@ -321,17 +322,18 @@ def main():
             log.error('Unable to retrieve altitude from Google APIs' +
                       'setting to 0')
 
-    log.info('Parsed location is: %.4f/%.4f/%.4f (lat/lng/alt)',
+    log.info('Parsed location is: %.4f/%.4f/%.4f (lat/lng/alt).',
              position[0], position[1], position[2])
 
-    if args.no_pokemon:
-        log.info('Parsing of Pokemon disabled.')
-    if args.no_pokestops:
-        log.info('Parsing of Pokestops disabled.')
-    if args.no_gyms:
-        log.info('Parsing of Gyms disabled.')
-    if args.encounter:
-        log.info('Encountering pokemon enabled.')
+    # Scanning toggles.
+    log.info('Parsing of Pokemon %s.',
+             'disabled' if args.no_pokemon else 'enabled')
+    log.info('Parsing of Pokestops %s.',
+             'disabled' if args.no_pokestops else 'enabled')
+    log.info('Parsing of Gyms %s.',
+             'disabled' if args.no_gyms else 'enabled')
+    log.info('Pokemon encounters %s.',
+             'enabled' if args.encounter else 'disabled')
 
     app = None
     if not args.no_server and not args.clear_db:
@@ -389,7 +391,7 @@ def main():
     wh_updates_queue = Queue()
     wh_key_cache = {}
 
-    if len(args.wh_types) == 0:
+    if not args.wh_types:
         log.info('Webhook disabled.')
     else:
         log.info('Webhook enabled for events: sending %s to %s.',
@@ -405,6 +407,14 @@ def main():
             t.start()
 
     if not args.only_server:
+        # Speed limit.
+        log.info('Scanning speed limit %s.',
+                 'set to {} km/h'.format(args.kph)
+                 if args.kph > 0 else 'disabled')
+        log.info('High-level speed limit %s.',
+                 'set to {} km/h'.format(args.hlvl_kph)
+                 if args.hlvl_kph > 0 else 'disabled')
+
         # Check if we are able to scan.
         if not can_start_scanning(args):
             sys.exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
quoted from stock RM
## Description
<!--- Describe your changes in detail -->
Setting --kph or --hlvl-kph to 0 will disable the appropriate speed checks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gyms can still be scanned even if an account is blinded (speed ban).
High-level account encounters don't do scan/GMO calls, only encounters.
Avoids discussions like:

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on my lab

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
