### PR TITLE
fix for AttributeError: 'int' object has no attribute 'pokemon_display'

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2263,7 +2263,7 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
             #Check for costform skin
             if pokemon_id == 351:
                 pokemon[p.encounter_id]['form'] = (p.pokemon_data
-                                                    .pokemon_display.form).pokemon_display.form
+                                                    .pokemon_display.form)
 
             # Updating Pokemon data from PGScout result
             if scout_result and scout_result['success']:


### PR DESCRIPTION
fix AttributeError: 'int' object has no attribute 'pokemon_display'

<!--- Provide a general summary of your changes in the Title above -->

## Description
This issue happened in last merged commit
`File "/home/RocketMap.SK/pogom/search.py", line 1195, in search_worker_thread
    account_sets)
  File "/home/RocketMap.SK/pogom/models.py", line 2265, in parse_map
    pokemon[p.encounter_id]['form'] = (p.pokemon_data
AttributeError: 'int' object has no attribute 'pokemon_display'`

Also causing to not insert the correct form of castform in the pokemon database (form column)

## Motivation and Context


## How Has This Been Tested?
Tested, work fine

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
