### PR TITLE
Add Idle / Busy counter to status page

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -532,6 +532,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
         'accounts_captcha': 0,
         'accounts_failed': 0,
         'active_accounts': 0,
+        'busy_accounts': 0,
         'skip_total': 0,
         'captcha_total': 0,
         'success_total': 0,
@@ -804,14 +805,20 @@ def get_stats_message(threadStatus, search_items_queue_array, db_updates_queue,
              len(account_failures), len(account_captchas))
 
     message += (
-        'Total active: {}  |  Success: {} ({:.1f}/hr) | ' +
-        'Fails: {} ({:.1f}/hr) | Empties: {} ({:.1f}/hr) | ' +
-        'Skips {} ({:.1f}/hr) | Captchas: {} ({:.1f}/hr) (${:.1f}/hr, ' +
-        '${:.1f}/mo) | Elapsed: {:.1f}h'
-    ).format(overseer['active_accounts'], overseer['success_total'], sph,
+        'Total active: {}, busy: {}, idle: {} | ' +
+        'Success: {} ({:.1f}/hr) | ' +
+        'Fails: {} ({:.1f}/hr) | ' +
+        'Empties: {} ({:.1f}/hr) | ' +
+        'Skips {} ({:.1f}/hr) | ' +
+        'Captchas: {} ({:.2f}/hr)|${:.2f}/hr|${:.2f}/mo | ' +
+        'Elapsed: {:.1f}h'
+    ).format(overseer['active_accounts'], overseer['busy_accounts'],
+             (overseer['active_accounts'] - overseer['busy_accounts']),
+             overseer['success_total'], sph,
              overseer['fail_total'], fph, overseer['empty_total'], eph,
              overseer['skip_total'], skph, overseer['captcha_total'], cph,
              ccost, cmonth, elapsed / 3600.0)
+
     return message
 
 
@@ -819,11 +826,16 @@ def update_total_stats(threadStatus, last_account_status):
     overseer = threadStatus['Overseer']
     # Calculate totals.
     active_count = 0
+    busy_count = 0
     current_accounts = Set()
     for tstatus in threadStatus.itervalues():
-        if tstatus.get('type', '') == 'Worker':
-            if tstatus.get('active', False):
+
+            is_active = tstatus.get('active', False)
+            if is_active:
                 active_count += 1
+
+            if is_active and tstatus.get('message', '') != 'Nothing to scan.':
+                busy_count += 1
 
             username = tstatus.get('username', '')
             current_accounts.add(username)
@@ -845,6 +857,7 @@ def update_total_stats(threadStatus, last_account_status):
             }
 
     overseer['active_accounts'] = active_count
+    overseer['busy_accounts'] = busy_count
 
     # Remove last status for accounts that workers
     # are not using anymore

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -829,6 +829,7 @@ def update_total_stats(threadStatus, last_account_status):
     busy_count = 0
     current_accounts = Set()
     for tstatus in threadStatus.itervalues():
+        if tstatus.get('type', '') =='Worker':
 
             is_active = tstatus.get('active', False)
             if is_active:

--- a/static/js/status.js
+++ b/static/js/status.js
@@ -6,12 +6,11 @@ var showInstances = true
 var showWorkers = true
 var hashkeys = {}
 var statshash = 'summarystats'  /* unique statistics worker name */
-var active
-var success
-var failed
-var empty
-var skipped
-var captcha
+var scansSuccess
+var scansFailed
+var scansEmpty
+var scansSkipped
+var captchasCount
 var mainWorkers
 var elapsedTotal
 var elapsedSecs
@@ -213,11 +212,11 @@ function addStatsWorker(hash) {
 }
 
 function getStats(i, worker) {
-    success += worker['success']
-    failed += worker['fail']
-    empty += worker['empty']
-    skipped += worker['skip']
-    captcha += worker['captcha']
+    scansSuccess += worker['success']
+    scansFailed += worker['fail']
+    scansEmpty += worker['empty']
+    scansSkipped += worker['skip']
+    captchasCount += worker['captcha']
     mainWorkers += 1
 
     elapsedTotal += worker['elapsed']
@@ -227,13 +226,11 @@ function getStats(i, worker) {
 
 function addTotalStats(result) {
     var statmsg, title
-
-    active = 0
-    success = 0
-    failed = 0
-    empty = 0
-    skipped = 0
-    captcha = 0
+    scansSuccess = 0
+    scansFailed = 0
+    scansEmpty = 0
+    scansSkipped = 0
+    captchasCount = 0
     mainWorkers = 0
     elapsedTotal = 0
     elapsedSecs = 0
@@ -249,16 +246,26 @@ function addTotalStats(result) {
     $.each(result.main_workers, getStats)
 
     if ((mainWorkers > 1) || !(showWorkers && showInstances)) {
-        active += result.workers.length
+        const accountsActive = result.workers.length
+
+        // Calculate the number of idle workers and then busy from that.
+        const accountsIdle = result.workers.reduce((accumulator, account) => {
+            if (account['message'] === 'Nothing to scan.') {
+                accumulator += 1
+            }
+            return accumulator
+        }, 0)
+
+        const accountsBusy = result.workers.length - accountsIdle
 
         // Avoid division by zero.
         elapsedSecs = Math.max(elapsedSecs, 1)
 
-        successPerHour = (success * 3600 / elapsedSecs) || 0
-        failsPerHour = (failed * 3600 / elapsedSecs) || 0
-        emptyPerHour = (empty * 3600 / elapsedSecs) || 0
-        skippedPerHour = (skipped * 3600 / elapsedSecs) || 0
-        captchasPerHour = (captcha * 3600 / elapsedSecs) || 0
+        successPerHour = (scansSuccess * 3600 / elapsedSecs) || 0
+        failsPerHour = (scansFailed * 3600 / elapsedSecs) || 0
+        emptyPerHour = (scansEmpty * 3600 / elapsedSecs) || 0
+        skippedPerHour = (scansSkipped * 3600 / elapsedSecs) || 0
+        captchasPerHour = (captchasCount * 3600 / elapsedSecs) || 0
         captchasCost = captchasPerHour * 0.00299
         captchasCostMonthly = captchasCost * 730
 
@@ -266,7 +273,8 @@ function addTotalStats(result) {
             addStatsWorker(statshash)
         }
 
-        statmsg = 'Total active: ' + active + ' | Success: ' + success.toFixed() + ' (' + successPerHour.toFixed(1) + '/hr) | Fails: ' + failed.toFixed() + ' (' + failsPerHour.toFixed(1) + '/hr) | Empties: ' + empty.toFixed() + ' (' + emptyPerHour.toFixed(1) + '/hr) | Skips: ' + skipped.toFixed() + ' (' + skippedPerHour.toFixed(1) + '/hr) | Captchas: ' + captcha.toFixed() + ' (' + captchasPerHour.toFixed(1) + '/hr) ($' + captchasCost.toFixed(1) + '/hr, $' + captchasCostMonthly.toFixed(1) + '/mo) | Elapsed:  ' + elapsedHours.toFixed(1) + 'h<hr />'
+        statmsg = 'Total active: ' + accountsActive + ', busy: ' + accountsBusy + ', idle: ' + accountsIdle + ' | Success: ' + scansSuccess.toFixed() + ' (' + successPerHour.toFixed(1) + '/hr) | Fails: ' + scansFailed.toFixed() + ' (' + failsPerHour.toFixed(1) + '/hr) | Empties: ' + scansEmpty.toFixed() + ' (' + emptyPerHour.toFixed(1) + '/hr) | Skips: ' + scansSkipped.toFixed() + ' (' + skippedPerHour.toFixed(1) + '/hr) | Captchas: ' + captchasCount.toFixed() + ' (' + captchasPerHour.toFixed(1) + '/hr) ($' + captchasCost.toFixed(2) + '/hr, $' + captchasCostMonthly.toFixed(2) + '/mo) | Elapsed:  ' + elapsedHours.toFixed(1) + 'h<hr />'
+
         if (mainWorkers > 1) {
             title = '(Total Statistics across ' + mainWorkers + ' instances)'
         } else {


### PR DESCRIPTION
## Description
Add Busy / Idle accounts to Status page
Stock RM PR #2479 - Commited

## Motivation and Context
Hard to keep track of how many accounts are busy/idle with many and large instances

## How Has This Been Tested?
Tested on my dev environment
Debian

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
