### PR TITLE
[Stock-RM] Add 'New Spawn' group [POST TRAVIS]

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -23,6 +23,7 @@ from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 from cHaversine import haversine
 from pprint import pformat
+from time import strftime
 from timeit import default_timer
 
 from pogom import dyn_img
@@ -532,6 +533,13 @@ def get_args():
     parser.add_argument('--log-path',
                         help=('Defines directory to save log files to.'),
                         default='logs/')
+    parser.add_argument('--log-filename',
+                        help=('Defines the log filename to be saved.'
+                              ' Allows date formatting, and replaces <SN>'
+                              " with the instance's status name. Read the"
+                              ' python time module docs for details.'
+                              ' Default: %%Y%%m%%d_%%H%%M_<SN>.log.'),
+                        default='%Y%m%d_%H%M_<SN>.log'),
     parser.add_argument('--dump',
                         help=('Dump censored debug info about the ' +
                               'environment and auto-upload to ' +
@@ -622,6 +630,11 @@ def get_args():
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()
+
+    # Allow status name and date formatting in log filename.
+    args.log_filename = strftime(args.log_filename)
+    args.log_filename = args.log_filename.replace('<sn>', '<SN>')
+    args.log_filename = args.log_filename.replace('<SN>', args.status_name)
 
     if args.only_server:
         if args.location is None:
@@ -1342,9 +1355,10 @@ def check_output_catch(command):
         return result.strip()
 
 
-# Automatically censor all necessary fields. Lists will return
-# their length, all other items will return 'censored_tag'.
-def _censor_args_namespace(args, censored_tag):
+# Automatically censor all necessary fields. Lists will return their
+# length, all other items will return 'empty_tag' if they're empty
+# or 'censored_tag' if not.
+def _censor_args_namespace(args, censored_tag, empty_tag):
     fields_to_censor = [
         'accounts',
         'accounts_L30',
@@ -1367,6 +1381,7 @@ def _censor_args_namespace(args, censored_tag):
         'db',
         'proxy_file',
         'log_path',
+        'log_filename',
         'encrypt_lib',
         'ssl_certificate',
         'ssl_privatekey',
@@ -1385,7 +1400,10 @@ def _censor_args_namespace(args, censored_tag):
         'status_name',
         'status_page_password',
         'hash_key',
-        'trusted_proxies'
+        'trusted_proxies',
+        'data_dir',
+        'locales_dir',
+        'shared_config'
     ]
 
     for field in fields_to_censor:
@@ -1397,7 +1415,10 @@ def _censor_args_namespace(args, censored_tag):
             if isinstance(value, list):
                 args[field] = len(value)
             else:
-                args[field] = censored_tag
+                if args[field]:
+                    args[field] = censored_tag
+                else:
+                    args[field] = empty_tag
 
     return args
 
@@ -1405,7 +1426,8 @@ def _censor_args_namespace(args, censored_tag):
 # Get censored debug info about the environment we're running in.
 def get_censored_debug_info():
     CENSORED_TAG = '<censored>'
-    args = _censor_args_namespace(vars(get_args()), CENSORED_TAG)
+    EMPTY_TAG = '<empty>'
+    args = _censor_args_namespace(vars(get_args()), CENSORED_TAG, EMPTY_TAG)
 
     # Get git status.
     status = check_output_catch('git status')

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1168,6 +1168,14 @@ function getPokemonRarity(pokemonId) {
     return i8ln('New Spawn')
 }
 
+function getPokemonRarity_noi8(pokemonId) {
+    if (pokemonRarities.hasOwnProperty(pokemonId)) {
+        return pokemonRarities[pokemonId]
+    }
+
+    return ''
+}
+
 function getGoogleSprite(index, sprite, displayHeight) {
     displayHeight = Math.max(displayHeight, 3)
     var scale = displayHeight / sprite.iconHeight
@@ -1211,7 +1219,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true, isNotifyPkmn
             'legendary': 50
         }
 
-        const pokemonRarity = getPokemonRarity(item['pokemon_id']).toLowerCase()
+        const pokemonRarity = getPokemonRarity_noi8(item['pokemon_id']).toLowerCase()
         if (rarityValues.hasOwnProperty(pokemonRarity)) {
             rarityValue = rarityValues[pokemonRarity]
         }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1165,7 +1165,7 @@ function getPokemonRarity(pokemonId) {
         return i8ln(pokemonRarities[pokemonId])
     }
 
-    return 'New Spawn'
+    return i8ln('New Spawn')
 }
 
 function getGoogleSprite(index, sprite, displayHeight) {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1165,7 +1165,7 @@ function getPokemonRarity(pokemonId) {
         return i8ln(pokemonRarities[pokemonId])
     }
 
-    return ''
+    return 'New Spawn'
 }
 
 function getGoogleSprite(index, sprite, displayHeight) {
@@ -1205,6 +1205,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true, isNotifyPkmn
 
     if (scaleByRarity) {
         const rarityValues = {
+            'new spawn': 40,
             'very rare': 30,
             'ultra rare': 40,
             'legendary': 50

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1168,7 +1168,7 @@ function getPokemonRarity(pokemonId) {
     return i8ln('New Spawn')
 }
 
-function getPokemonRarity_noi8(pokemonId) {
+function getPokemonRarityNoi8(pokemonId) {
     if (pokemonRarities.hasOwnProperty(pokemonId)) {
         return pokemonRarities[pokemonId]
     }
@@ -1219,7 +1219,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true, isNotifyPkmn
             'legendary': 50
         }
 
-        const pokemonRarity = getPokemonRarity_noi8(item['pokemon_id']).toLowerCase()
+        const pokemonRarity = getPokemonRarityNoi8(item['pokemon_id']).toLowerCase()
         if (rarityValues.hasOwnProperty(pokemonRarity)) {
             rarityValue = rarityValues[pokemonRarity]
         }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1173,7 +1173,7 @@ function getPokemonRarityNoi8(pokemonId) {
         return pokemonRarities[pokemonId]
     }
 
-    return ''
+    return 'New Spawn'
 }
 
 function getGoogleSprite(index, sprite, displayHeight) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2975,7 +2975,7 @@ $(function () {
         })
         $selectRarityNotify.select2({
             placeholder: i8ln('Select Rarity'),
-            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare')],
+            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare'), i8ln('New Spawn')],
             templateResult: formatState
         })
 
@@ -3041,9 +3041,10 @@ $(function () {
         $selectExcludeRarity.val(Store.get('excludedRarity')).trigger('change')
     })
 
-    // run interval timers to regularly update map and timediffs
+    // run interval timers to regularly update map, rarity and timediffs
     window.setInterval(updateLabelDiffTime, 1000)
     window.setInterval(updateMap, 5000)
+    window.setInterval(updatePokemonRarities, 300000)
     window.setInterval(updateGeoLocation, 1000)
 
     createUpdateWorker()

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -824,6 +824,7 @@
   "Nature Power": "Natur-Kraft",
   "Nature's Madness": "Naturzorn",
   "Needle Arm": "Nietenranke",
+  "New Spawn": "Neuer Spawn",
   "Nidoking": "Nidoking",
   "Nidoqueen": "Nidoqueen",
   "Nidoran♀": "Nidoran♀",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -822,6 +822,7 @@
   "Nature Power": "Force-Nature",
   "Nature's Madness": "Ire de la Nature",
   "Needle Arm": "Poing Dard",
+  "New Spawn": "Nouveau Spawn",
   "Nidoking": "Nidoking",
   "Nidoqueen": "Nidoqueen",
   "Nidoran♀": "Nidoran♀",

--- a/static/locales/zh_hk.json
+++ b/static/locales/zh_hk.json
@@ -418,6 +418,7 @@
   "Murkrow": "Murkrow", 
   "Musharna": "Musharna", 
   "Natu": "Natu", 
+  "New Spawn": "新出現",
   "Nidoking": "尼多王", 
   "Nidoqueen": "尼美后", 
   "Nidoran♀": "尼美蘭", 


### PR DESCRIPTION
## Description
There is a current issue of a brand new pokemon spawn and it will not be set a rarity until the dynamic rarity filer is updated.

We could set all new pokemon to ultra rare but for people who dont update rarity often this would mean things as common as pidgey would stay ultra rare until rarity file is next updated.

This way sets all new pokemon as a "New Spawn" and once the rarity file is updated it will be sorted properly. I added "New Spawn" to notify by rarity on the side bar and also included it in scale by rarity.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Local instance. Works fine

**My instances screenshot**
![image](https://user-images.githubusercontent.com/21128187/37753984-d6e73c44-2d9f-11e8-86e4-def857a7e49b.png)

## Screenshots (if appropriate):

**Original PR Screenshot**
![image](https://user-images.githubusercontent.com/21128187/37753956-ba4e32ae-2d9f-11e8-8e01-2cb0b956dc4c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
