### PR TITLE
[Stock-Rm] Adds buttons to the menu to export / import the settings [POST TRAVIS]

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -198,6 +198,25 @@ function createServiceWorkerReceiver() {
     })
 }
 
+function downloadSettings(name, settings) { // eslint-disable-line no-unused-vars
+    var a = document.createElement('a')
+    a.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(settings))
+    a.setAttribute('download', name + '_' + moment().format('DD-MM-YYYY HH:mm'))
+    a.style.display = 'none'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+}
+
+function loadSettingsFile(file) { // eslint-disable-line no-unused-vars
+    var reader = new FileReader()
+    reader.onload = function () {
+        Object.assign(localStorage, JSON.parse(reader.result))
+    }
+    reader.readAsText(file.target.files[0])
+    window.location.reload()
+}
+
 function initMap() { // eslint-disable-line no-unused-vars
     map = new google.maps.Map(document.getElementById('map'), {
         center: {

--- a/templates/map.html
+++ b/templates/map.html
@@ -515,6 +515,8 @@
           </div>
         </div>
       <div>
+        <center><button class="settings" onclick="downloadSettings('RocketMap', JSON.stringify(localStorage))"><i class="fa fa-upload fa-fw"></i>Export Settings</button></center>
+        <center><input id="settingsFileInput" type="file" style="display:none;" onchange="loadSettingsFile(event)"> <button class="settings" onclick="document.getElementById('settingsFileInput').click()"><i class="fa fa-download fa-fw"></i>Import Settings</button></center>
         <center><button class="settings" onclick="confirm('Are you sure you want to reset settings to default values?') ? (localStorage.clear(), window.location.reload()) : false"><i class="fa fa-refresh fa-fw"></i>Reset Settings</button></center>
       </div>
       </nav>


### PR DESCRIPTION
## Description

"Adds buttons to the menu to export / import the settings."

## Motivation and Context

"Because the settings are stored in "Local Storage", they can be lost. Not anymore! You can export the settings for a later import.

By default, the file will have the following names: "RocketMap_DD-MM-YYYY HH:mm.txt".
If you want, you can change the main name of the file under "templates/map.html" on line 464:
`<button class="settings" onclick="downloadSettings('RocketMap', JSON.stringify(localStorage))">`. Change "RocketMap" in everything you want. (Maybe it would be better to put it in the config, but unfortunately I don't know how to do this. The question is, if this option is necessary. Because if you download it you can put a name of your own.)"

**Port of Stock-RM PR**

## How Has This Been Tested?

Local instance

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/21128187/37816245-96fef972-2e72-11e8-84c7-8cf6ecabed12.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
