### PR TITLE
Adding an option to hide the Pokemon stats when encounters are activated

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -46,6 +46,17 @@ def convert_pokemon_list(pokemon):
                 transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
         pokemon_result.append(p)
 
+        if args.hide_encounters:
+            p['cp'] = None
+            p['cp_multiplier'] = None
+            p['height'] = None
+            p['individual_attack'] = None
+            p['individual_defense'] = None
+            p['individual_stamina'] = None
+            p['move_1'] = None
+            p['move_2'] = None
+            p['weigth'] = None
+
     # Re-enable the GC.
     gc.enable()
     return pokemon

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -174,6 +174,9 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves.',
                         action='store_true', default=False)
+    parser.add_argument('-hide', '--hide-encounters',
+                        help='Hide the encounter stats from the web',
+                        action='store_true', default=False)
     parser.add_argument('-cs', '--captcha-solving',
                         help='Enables captcha solving.',
                         action='store_true', default=False)


### PR DESCRIPTION
With this commit the backend is prevented from return any statistic, even when the encounters are activated. So, the web page won't be able to show any information, even when an user modify the JavaScript variables.

Perfect to prevent web scrapping of the IV statistics